### PR TITLE
[CBP-38214] - Update Docker image version for kubernetes job

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     - id: kuberenetes-render
       name: invoke-kubernetes-job
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/kubernetes-resource-actions:main-6ebc0c5ff76d869a8e3f974b59e97835bfc7e9da
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/kubernetes-resource-actions:main-df89ccf14625c3ea401493e4fe192de28a6689aa
       shell: sh
       env:
         CONFIG_JSON: '{"metaInfo":{"toolType":"KUBERENETES_ACTIONS","filePath":"${{ inputs.file-path }}","environmentVariables":${{ inputs.environment-variables }},"environmentVariablesPath":"${{ inputs.environment-variables-path }}"}}'


### PR DESCRIPTION
Update docker image to main-df89ccf14625c3ea401493e4fe192de28a6689aa

Image already exists in public.ecr.aws/l7o7z1g8/actions/kubernetes-resource-actions:main-df89ccf14625c3ea401493e4fe192de28a6689aa